### PR TITLE
Adjust the noop in backend and endpoints when selected

### DIFF
--- a/src/app/designer.controller.js
+++ b/src/app/designer.controller.js
@@ -46,7 +46,8 @@ angular
     };
 
     $rootScope.setDefaultData = function () {
-        if ( typeof $rootScope.service.extra_config['krakendesigner']['endpoint_defaults'] === 'undefined') {
+        if ('undefined' === typeof $rootScope.service.extra_config['krakendesigner'] ||
+            'undefined' === typeof $rootScope.service.extra_config['krakendesigner']['endpoint_defaults']) {
             return false;
         }
 
@@ -247,6 +248,40 @@ angular
         }
     };
 
+    /**
+     * The setNoOpEncoding is called when the backend or the endpoint change their encoding.
+     * It deletes all backend configuration and adds a backend with no-op.
+     */
+    $rootScope.setNoOpEncoding = function(endpoint_index, new_value, old_value, backend_index) {
+        var message = "Working with the No-Operation encoder/decoder means that the endpoint will proxy all content using a *single backend* and response manipulation is not available.\n\nSelecting this option will set the encoding of both the endpoint and the backend to noop and will leave the backend for proxying only.\n Do you want to proceed?";
+        var num_backends = ( 'undefined' === typeof $rootScope.service.endpoints[endpoint_index].backend ? 0 : $rootScope.service.endpoints[endpoint_index].backend.length );
+
+        // Endpoint encoding and backend encoding must match to 'no-op':
+        if (new_value == 'noop' && num_backends > 0) {
+
+            if ( confirm(message) )
+            {
+                // Delete all backend queries and add just one, inheriting encoding:
+                delete $rootScope.service.endpoints[endpoint_index].backend
+                $rootScope.service.endpoints[endpoint_index].output_encoding = 'noop';
+                $rootScope.addBackendQuery(endpoint_index);
+
+            } else { // Angular already updated the values, revert endpoint or backend:
+
+                if ( null === backend_index )
+                {
+                    // Backend encoding
+                    $rootScope.service.endpoints[endpoint_index].output_encoding = old_value;
+                }
+                else
+                {
+                    $rootScope.service.endpoints[endpoint_index].backend[backend_index].encoding = old_value;
+                }
+            }
+        }
+    }
+
+
 
     $rootScope.addBackendQuery = function (endpoint_index) {
 
@@ -254,7 +289,10 @@ angular
             $rootScope.service.endpoints[endpoint_index].backend = [];
         }
 
-        $rootScope.service.endpoints[endpoint_index].backend.push({"url_pattern": "/"});
+        $rootScope.service.endpoints[endpoint_index].backend.push({
+            "url_pattern": "/",
+            "encoding": $rootScope.service.endpoints[endpoint_index].output_encoding
+        });
     };
 
     $rootScope.toggleCaching = function($event, endpoint_index, backend_index) {

--- a/src/app/forms/endpoints.html
+++ b/src/app/forms/endpoints.html
@@ -78,7 +78,8 @@
                             ng-model="endpoint.output_encoding"
                             id="endpoint.output_encoding"
                             name="endpoint.output_encoding"
-                            ng-init="endpoint.output_encoding=service.output_encoding">
+                            ng-init="endpoint.output_encoding=service.output_encoding",
+                            ng-change="setNoOpEncoding(endpoint_index, endpoint.output_encoding, '{{ endpoint.output_encoding }}', null)">
                             <option value="json">JSON</option>
                             <option value="negotiate">Negotiate content</option>
                             <option value="string">String (text/plain)</option>
@@ -291,16 +292,19 @@
                                 <h4>Authorization</h4>
                                 <oauth data="backend" inherit="service.extra_config['github_com/devopsfaith/krakend-oauth2-clientcredentials']"></oauth>
                                 <hr/>
+                                <div ng-if="endpoint.output_encoding != 'noop'">
                                 <h4>Response Parsing</h4>
                                 <div class="form-group">
                                     <div class="col-md-4">
                                         <label>Decode as:</label>
                                         <select class="form-control" ng-model="backend.encoding"
-                                                ng-init="backend.encoding ='json'">
+                                                ng-init="backend.encoding ='json'"
+                                                ng-change="setNoOpEncoding(endpoint_index, backend.encoding, '{{ backend.encoding }}', backend_index)">
                                             <option selected value="json">JSON</option>
                                             <option value="xml">XML</option>
                                             <option value="rss">RSS</option>
                                             <option value="string">String</option>
+                                            <option value="noop">No-Op</option>
                                         </select>
                                         <span class="help-block">How to decode the response of the backend.</span>
                                     </div>
@@ -332,7 +336,9 @@
                                 </div>
                                 <hr/>
 
+
                                 <h4>Response manipulation</h4>
+
                                 <p>Transform here the response with a lighter version, include only the attributes that
                                     your
                                     application needs.</p>
@@ -467,8 +473,8 @@
                                         <span class="help-block">You can rename any attributes returned by the backend and use a name more convenient for you.</span>
                                     </div>
                                 </div>
-
                                 <hr/>
+
                                 <h4>Advanced - Martian DSL</h4>
                                 <p>Paste here any additional configuration you want to add to <a href="https://github.com/google/martian#modifiers-all-the-way-down">Martian</a>. The input must be a JSON object (ensure to start and end with curly braces <code>{}</code>)</p>
                                  <div class="form-group">
@@ -485,6 +491,7 @@
                                     </div>
                                 </div>
                             </div>
+                            </div><!-- ngif output_encoding != noop -->
                             <!-- /.box-body -->
                         </div>
 
@@ -548,7 +555,7 @@
                 </div>
                 <button class="btn btn-primary"
                         ng-click="addBackendQuery(endpoint_index)"
-                        ng-if="! endpoint.backend || endpoint.backend.length < 1 || endpoint.method =='GET'">
+                        ng-if="! endpoint.backend || endpoint.backend.length < 1 || ( endpoint.method =='GET' && !(endpoint.output_encoding == 'noop' && endpoint.backend.length > 0))">
                     <span class="glyphicon glyphicon glyphicon-plus" aria-hidden="true"></span>
                     Add backend query
                 </button>


### PR DESCRIPTION
Expected behavior:
- Selecting noop in the endpoint or backend wipes all data in backends and adds a new backend using noop
- Adding a new backend always carries the output_encoding as encoding.
- When noop is used in the backend, no response manipulation is shown