### PR TITLE
Krakend 0.5: Add static/fallback responses

### DIFF
--- a/src/app/designer.controller.js
+++ b/src/app/designer.controller.js
@@ -255,7 +255,7 @@ angular
      * It deletes all backend configuration and adds a backend with no-op.
      */
     $rootScope.setNoOpEncoding = function(endpoint_index, new_value, old_value, backend_index) {
-        var message = "Working with the No-Operation encoder/decoder means that the endpoint will proxy all content using a *single backend* and response manipulation is not available.\n\nSelecting this option will set the encoding of both the endpoint and the backend to noop and will leave the backend for proxying only.\n Do you want to proceed?";
+        var message = "Selecting the No-Operation means that this endpoint will proxy all content to a *single backend* where no response manipulation is desired.\n\nThe noop option will be automatically set for both the backend and the endpoint. Existing backend settings for this endpoint will be discarded.\n\n Do you want to proceed?";
         var num_backends = ( 'undefined' === typeof $rootScope.service.endpoints[endpoint_index].backend ? 0 : $rootScope.service.endpoints[endpoint_index].backend.length );
 
         // Endpoint encoding and backend encoding must match to 'no-op':
@@ -267,6 +267,11 @@ angular
                 delete $rootScope.service.endpoints[endpoint_index].backend
                 $rootScope.service.endpoints[endpoint_index].output_encoding = 'noop';
                 $rootScope.addBackendQuery(endpoint_index);
+
+                // Delete also static_response
+                if ( 'undefined' !== typeof $rootScope.service.endpoints[endpoint_index].extra_config['github.com/devopsfaith/krakend/proxy'] ) {
+                    delete $rootScope.service.endpoints[endpoint_index].extra_config['github.com/devopsfaith/krakend/proxy'];
+                }
 
             } else { // Angular already updated the values, revert endpoint or backend:
 
@@ -310,6 +315,26 @@ angular
         if (confirm(message)) {
             $rootScope.service.endpoints[endpoint_index].backend.splice(backend_index, 1);
         }
+    };
+
+    $rootScope.addDefaultStaticResponse = function (endpoint_index) {
+        if (typeof $rootScope.service.endpoints[endpoint_index].extra_config['github.com/devopsfaith/krakend/proxy'] == "undefined") {
+
+            $rootScope.service.endpoints[endpoint_index].extra_config['github.com/devopsfaith/krakend/proxy'] = {
+                "static": {
+                    "data" : {
+                        "new_field_a": 123,
+                        "new_field_b": ["arr1","arr2"],
+                        "new_field_c": {"obj": "obj1"}
+                    },
+                    "strategy": "incomplete"
+                }
+            }
+        }
+    };
+
+     $rootScope.deleteStaticResponse = function (endpoint_index) {
+            delete $rootScope.service.endpoints[endpoint_index].extra_config['github.com/devopsfaith/krakend/proxy'];
     };
 
     $rootScope.addQuerystring = function (endpoint_index) {

--- a/src/app/endpoint/json-formatter.directive.js
+++ b/src/app/endpoint/json-formatter.directive.js
@@ -8,11 +8,15 @@ angular
 		link: function(scope, element, attrs, ngModel) {
 			function toObject(input) {
 				try {
-					json_object = JSON.parse(input);
-					scope.$parent.backend.martian_syntax_validation = true;
+					var json_object = null;
+					if ( '' != input ) {
+						json_object = JSON.parse(input);
+					}
+					delete scope.service.extra_config['krakendesigner'].json_errors;
 					return json_object;
 				} catch(e) {
-					scope.$parent.backend.martian_syntax_validation = e.message;
+					scope.service.extra_config['krakendesigner'].json_valid = true;
+					scope.service.extra_config['krakendesigner'].json_errors = e.message;
 					return false;
 				}
 			}

--- a/src/app/forms/endpoints.html
+++ b/src/app/forms/endpoints.html
@@ -182,7 +182,44 @@
                 </div>
                 <div class="form-group">
                     <div class="col-md-12">
-                        <h4>Backend queries (where the data comes from)</h4>
+                         <h4>Backend API calls (where the data comes from)</h4>
+                    </div>
+                    <div class="col-md-12" ng-if="endpoint.extra_config['github.com/devopsfaith/krakend/proxy'].static">
+                        <div class="box box-info box-solid">
+                            <div class="box-header with-border">
+                                <h3 class="box-title">Static Response</h3>
+                                <div class="box-tools pull-right">
+                                    <button type="button" class="btn btn-box-tool" data-widget="collapse">
+                                        <i class="fa fa-minus"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-box-tool" ng-click="deleteStaticResponse(endpoint_index)">
+                                        <i class="fa fa-trash"></i>
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div class="box-body">
+                                <p>The following static data will be added to the response following the selected strategy. The input must be a JSON object (ensure to start and end with curly braces <code>{}</code>)</p>
+                                <div class="col-md-8">
+
+                                    <label class="control-label">Response</label>
+                                    <textarea json-formatter class="form-control" ng-model="endpoint.extra_config['github.com/devopsfaith/krakend/proxy'].static.data"></textarea>
+                                    <p ng-show="service.extra_config['krakendesigner'].json_errors" class="badge label-danger">
+                                        <i class="fa fa-warning"></i> Syntax error - {{ service.extra_config['krakendesigner'].json_errors}}
+                                    </p>
+                                    <span class="help-block">Paste here your JSON response</span>
+                                </div>
+                                <div class="col-md-4">
+                                    <label class="control-label">Strategy</label>
+                                    <select class="form-control" ng-model="endpoint.extra_config['github.com/devopsfaith/krakend/proxy'].static.strategy">
+                                        <option value="always">Always - Present in every response</option>
+                                        <option value="success">Success - Present in every non-failed response </option>
+                                        <option value="errored">Errored - Present in every failed response (error not nil)</option>
+                                        <option value="incomplete">Incomplete - Present in incomplete responses</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="col-md-12"
                          ng-repeat="(backend_index,backend) in endpoint.backend">
@@ -556,6 +593,12 @@
 
 
                 </div>
+                <button class="btn btn-primary"
+                    ng-click="addDefaultStaticResponse(endpoint_index)"
+                    ng-if="! endpoint.extra_config['github.com/devopsfaith/krakend/proxy'].static  &&   !(endpoint.output_encoding == 'noop' && endpoint.backend.length > 0)">
+                    <span class="glyphicon glyphicon glyphicon-plus" aria-hidden="true"></span>
+                    Add static response
+                </button>
                 <button class="btn btn-primary"
                         ng-click="addBackendQuery(endpoint_index)"
                         ng-if="! endpoint.backend || endpoint.backend.length < 1 || ( endpoint.method =='GET' && !(endpoint.output_encoding == 'noop' && endpoint.backend.length > 0))">


### PR DESCRIPTION
Added static responses to enable setting fake/static/fixed data upon backend response using one of the four strategies:

- Always - Present in every response
- Success - Present in every non-failed response
- Errored - Present in every failed response (error not nil)
- Incomplete - Present in incomplete responses

The static response cannot be combined with No-Op and the interface ensures this.