### PR TITLE
Add GELF logging

### DIFF
--- a/src/app/forms/logging.html
+++ b/src/app/forms/logging.html
@@ -1,5 +1,6 @@
 <div class="col-md-6">
   <middleware data="service" template="gologging.html" namespace="'github_com/devopsfaith/krakend-gologging'"></middleware>
+  <middleware ng-if="service.extra_config['github_com/devopsfaith/krakend-gologging']" data="service" template="gelf.html" namespace="'github_com/devopsfaith/krakend-gelf'"></middleware>
   <middleware data="service" template="metrics.html" namespace="'github_com/devopsfaith/krakend-metrics'"></middleware>
 </div>
 <div class="col-md-6">

--- a/src/app/middlewares/gelf.html
+++ b/src/app/middlewares/gelf.html
@@ -1,0 +1,35 @@
+<div class="box box-primary">
+  <div class="box-header with-border">
+    <h3 class="box-title"><input type="checkbox"
+          ng-checked="isMiddlewareEnabled()"
+          ng-click="toggleMiddleware()"> GELF</h3>
+  </div>
+
+  <div class="box-body" ng-if="isMiddlewareEnabled()">
+    <p>Writes logs using GELF (Graylog Extended Log Format)</p>
+    <div class="row">
+      <div class="col-md-12">
+        <label class="control-label">Address</label>
+
+        <input type="text"
+        class="form-control"
+        ng-model="data.extra_config[config_namespace].address"
+        placeholder="myGraylogInstance:12201">
+
+        <div class="help-block">
+          The address (including the port) of your graylog server (or any service that receives gelf inputs).
+        </div>
+      </div>
+  </div>
+  <div class="form-group">
+    <div class="checkbox">
+      <label>
+        <input type="checkbox"
+        ng-model="data.extra_config[config_namespace].enable_tcp">
+        <strong>Enable TCP</strong>
+      </label>
+      <span class="help-block">By default uses UDP but you can enable TCP by setting this option to true (not recommended, your performance might suffer).</span>
+    </div>
+  </div>
+</div>
+</div>


### PR DESCRIPTION
Adds the GELF logging option when gologging is enabled

```
 "github_com/devopsfaith/krakend-gelf": {
      "address": "instance:PORT",
      "enable_tcp": false
    }
```