### PR TITLE
Connected JWT-Validation configuration between endpoints #82

### DIFF
--- a/src/app/middlewares/middleware.directive.js
+++ b/src/app/middlewares/middleware.directive.js
@@ -18,9 +18,9 @@ angular
       var NAMESPACE = scope.namespace;
       var default_middleware_data = {};
 
-      // Load default values from default_config.service.js when present:
+      // Copy default values from default_config.service.js when present:
       if ( 'undefined' !== typeof DefaultConfig.extra_config[NAMESPACE]) {
-        default_middleware_data = DefaultConfig.extra_config[NAMESPACE];
+        default_middleware_data = Object.assign({}, DefaultConfig.extra_config[NAMESPACE]);
       }
 
       // Create extra_config key and merge with existing content:


### PR DESCRIPTION
Middleware directive was passing configuration from its ancestors by reference, instead of value.